### PR TITLE
Update MixinClientPlayerEntity.java

### DIFF
--- a/src/main/java/me/cioco/antiafk/mixin/MixinClientPlayerEntity.java
+++ b/src/main/java/me/cioco/antiafk/mixin/MixinClientPlayerEntity.java
@@ -32,8 +32,8 @@ public class MixinClientPlayerEntity {
 
         boolean utiltick = player.age % IntervalCommand.interval == 0;
 
-        int moveX = (random.nextInt(11) - 5) * (int) AntiAfkConfig.horizontalMultiplier;
-        int moveY = (random.nextInt(11) - 5) * (int) AntiAfkConfig.verticalMultiplier;
+        float moveX = (random.nextInt(11) - 5) * AntiAfkConfig.horizontalMultiplier;
+        float moveY = (random.nextInt(11) - 5) * AntiAfkConfig.verticalMultiplier;
 
         if (Main.toggled) {
             if (AntiAfkConfig.autoJumpEnabled && utiltick && player.isOnGround()) {


### PR DESCRIPTION
Solves issue where horizontal and vertical camera movement multiplier values are converted to int, not allowing float adjustments.